### PR TITLE
closes #64: updated waffle title to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# crewapp [![Stories in Ready](https://badge.waffle.io/crewapp/crewapp.png?label=ready&title=Ready)](https://waffle.io/crewapp/crewapp)
+# crewapp [![Stories in Ready](https://badge.waffle.io/crewapp/crewapp.png?label=in%20progress&title=In%20Progress)](https://waffle.io/crewapp/crewapp)
 The crew chooses you!
 
 # Installation Directions


### PR DESCRIPTION
Because `Waffle.io` uses labels to return a count. I switched over from checking `ready` to checking for labels with the `in progress` tag. This will allow us to see which issues are `in progress`.
