### PR TITLE
closes #56: grunt test now allows for js and jsx

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,47 @@
+{
+    "parser": "esprima-fb",
+    "env": {
+        "browser": true,
+        "node": true
+    },
+
+    "rules": {
+        "no-mixed-requires": [0, false],
+        "quotes": [2, "single"],
+        "strict": [1, "never"],
+        "semi": [2, "always"],
+        "curly": 1,
+        "no-bitwise": 1,
+        "max-len": [1, 110, 4],
+        "vars-on-top": 0,
+        "guard-for-in": 1,
+        "react/display-name": 1,
+        "react/jsx-quotes": [2, "double", "avoid-escape"],
+        "react/jsx-no-undef": 2,
+        "react/jsx-sort-props": 0,
+        "react/jsx-uses-react": 1,
+        "react/jsx-uses-vars": 1,
+        "react/no-did-mount-set-state": 2,
+        "react/no-did-update-set-state": 2,
+        "react/no-multi-comp": 0,
+        "react/no-unknown-property": 1,
+        "react/prop-types": 2,
+        "react/react-in-jsx-scope": 1,
+        "react/self-closing-comp": 1,
+        "react/wrap-multilines": 2
+    },
+
+    "ecmaFeatures": {
+        "jsx": true
+    },
+
+    "plugins": [ "react" ],
+
+    "globals": {
+        "d3": true,
+        "require": "true",
+        "module": "true",
+        "$": "true",
+        "d3": "true"
+    }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,16 +19,22 @@ module.exports = function(grunt) {
     jshint: {
       options: {
         jshintrc: '.jshintrc',
-        ignores: ['./**/node_modules'],
-        additionalSuffixes: ['.ios.js']
+        ignores: ['./**/node_modules', '**/*.ios.js'], 
       },
       all: ['./']
+    },
+    eslint: {
+      options: {
+        eslintrc: '.eslintrc',
+      },
+      target: ['./app/index.ios.js']
     }
   });
 
   grunt.loadNpmTasks('grunt-shell');
-  grunt.loadNpmTasks('grunt-jsxhint');
-  
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-eslint');
+
   /* Build Tasks */
   grunt.registerTask('build-web', ['shell:build-web']);
   grunt.registerTask('build-app', ['shell:build-app']);
@@ -36,5 +42,5 @@ module.exports = function(grunt) {
   grunt.registerTask('build', ['build-web', 'build-app']);
 
   /* Testing */
-  grunt.registerTask('test', ['jshint']);
+  grunt.registerTask('test', ['jshint', 'eslint']);
 };

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
   },
   "homepage": "https://github.com/arianf/crewapp",
   "dependencies": {
+    "eslint": "^0.18.0",
+    "eslint-plugin-react": "^2.1.0",
+    "esprima-fb": "^14001.1.0-dev-harmony-fb",
     "grunt": "^0.4.5",
-    "grunt-jsxhint": "^0.6.0",
+    "grunt-contrib-jshint": "^0.11.1",
     "grunt-shell": "^1.1.2",
     "react-tools": "^0.13.1"
   }


### PR DESCRIPTION
Worked with @koziscool and @pravipati to get this working.

`grunt test` runs `jshint` on all `.js` files. and runs a custom `eslint` for jsx on `index.os.js`
