### PR TITLE
closes #89: fixed the misdirected link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# crewapp [![travisci](https://travis-ci.org/crewapp/crewapp.svg?branch=master)](https://waffle.io/crewapp/crewapp) [![Stories in progress](https://badge.waffle.io/crewapp/crewapp.png?label=in%20progress&title=In%20Progress)](https://waffle.io/crewapp/crewapp)
+# crewapp [![Build Status](https://travis-ci.org/crewapp/crewapp.svg?branch=master)](https://travis-ci.org/crewapp/crewapp) [![Stories in progress](https://badge.waffle.io/crewapp/crewapp.png?label=in%20progress&title=In%20Progress)](https://waffle.io/crewapp/crewapp)
 The crew chooses you!
 
 # Installation Directions


### PR DESCRIPTION
Fixes the link to be pointing to travis.ci instead of waffle.io
