### PR TITLE
closes #93: script now runs server side script

### DIFF
--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 # start forever with port 2368
-cd /home/ubuntu/public/server/
-PORT=2368 forever start server.js
+bash ~/config.sh
 


### PR DESCRIPTION
This is fixed now, the server should run a bash script instead of running a script from github.
