### PR TITLE
closes #99: fixes deploy bug

### DIFF
--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 # start forever with port 2368
-bash ~/config.sh
+bash /home/ubuntu/config.sh
 


### PR DESCRIPTION
Changed the directory that is being run to be exact instead of using `~` as the start point.
