### PR TITLE
closes #97: fixes async bug with table creation

### DIFF
--- a/server/database/index.js
+++ b/server/database/index.js
@@ -49,9 +49,9 @@ var Group = sequelize.define('groups', {
 // User.hasMany(Message);
 // Message.belongsTo(Group);
 
-Group.sync({force: false});
-User.sync({force: false});
-Message.sync({force: false});
+// force: true drops all tables
+// which is good for testing, and bad for production
+sequelize.sync({force: true});
 
 
 


### PR DESCRIPTION
This fixes a bug that would call sync asynchronously, which would imply that the order of the called functions wasn't guaranteed. When calling `sequelize.sync();` instead, we get the sequelize to handle the order of the events.
