### PR TITLE
Closes #96: Sign-Up/Log-In Flow

### DIFF
--- a/app/index.ios.js
+++ b/app/index.ios.js
@@ -1,8 +1,7 @@
 var styles = require('./styles.js');
 var React = require('react-native');
 
-// var ChatRoom = require('./views/ChatRoom');
-var SignUp = require('./views/SignUp');
+var SplashPage = require('./views/SplashPage');
 
 var {
   AppRegistry,
@@ -17,8 +16,8 @@ var app = React.createClass({
         style={styles.container}
         tintColor="#FF6600"
         initialRoute={{
-          title: 'Sign Up',
-          component: SignUp
+          title: 'Crew App',
+          component: SplashPage
         }} />
     );
   }

--- a/app/index.ios.js
+++ b/app/index.ios.js
@@ -1,7 +1,8 @@
 var styles = require('./styles.js');
 var React = require('react-native');
 
-var ChatRoom = require('./views/ChatRoom');
+// var ChatRoom = require('./views/ChatRoom');
+var SignUp = require('./views/SignUp');
 
 var {
   AppRegistry,
@@ -16,8 +17,8 @@ var app = React.createClass({
         style={styles.container}
         tintColor="#FF6600"
         initialRoute={{
-          title: 'Chat Room',
-          component: ChatRoom
+          title: 'Sign Up',
+          component: SignUp
         }} />
     );
   }

--- a/app/views/ChatRoom/index.js
+++ b/app/views/ChatRoom/index.js
@@ -85,7 +85,6 @@ var ChatList = React.createClass({
 var MessageForm = React.createClass({
   onPress: function() {
     var value = this.refs.form.getValue();
-    console.log('inside onPress -> value !');
     if (value) {
       this.send(value);
     }

--- a/app/views/ChatRoom/styles.js
+++ b/app/views/ChatRoom/styles.js
@@ -34,4 +34,3 @@ var styles = StyleSheet.create({
 });
 
 module.exports = styles;
-

--- a/app/views/Login/index.js
+++ b/app/views/Login/index.js
@@ -20,19 +20,19 @@ var LoginFields = t.struct({
 var options = {
   fields: {
     username: {
-      placeholder: 'Choose a username',
-      error: 'You have to enter a username!'
+      placeholder: 'Your username',
+      error: 'You have to enter your username!'
     },
     password: {
       password: true,
       secureTextEntry: true,
-      placeholder: 'Choose a password',
+      placeholder: 'Enter your password',
       error: 'You have to enter your password!'
     }
   }
 };
 
-var SignUp = React.createClass({
+var Login = React.createClass({
   onPress: function() {
     this.props.navigator.push({
       title: 'Chat Room',
@@ -51,7 +51,7 @@ var SignUp = React.createClass({
             type={LoginFields}
             options={options} />
           <TouchableHighlight style={styles.button} onPress={this.onPress} underlayColor="#99d9f4">
-            <Text style={styles.buttonText}>Create Account</Text>
+            <Text style={styles.buttonText}>Log In</Text>
           </TouchableHighlight>
         </View>
       </View>
@@ -59,4 +59,4 @@ var SignUp = React.createClass({
   }
 });
 
-module.exports = SignUp;
+module.exports = Login;

--- a/app/views/Login/styles.js
+++ b/app/views/Login/styles.js
@@ -1,0 +1,32 @@
+var React = require('react-native');
+var { StyleSheet } = React;
+
+var styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ffffff'
+  },
+  formBox: {
+    marginTop: 50,
+    padding: 20,
+    position: 'relative'
+  },
+  buttonText: {
+    fontSize: 18,
+    color: 'white',
+    alignSelf: 'center'
+  },
+  button: {
+    height: 36,
+    backgroundColor: '#48BBEC',
+    borderColor: '#48BBEC',
+    borderWidth: 1,
+    borderRadius: 8,
+    marginBottom: 10,
+    alignSelf: 'flex-end',
+    justifyContent: 'center'
+  }
+});
+
+module.exports = styles;

--- a/app/views/SignUp/index.js
+++ b/app/views/SignUp/index.js
@@ -1,0 +1,65 @@
+var styles = require('./styles.js');
+var React = require('react-native');
+
+var t = require('tcomb-form-native');
+var Form = t.form.Form;
+
+var ChatRoom = require('../ChatRoom');
+
+var {
+  Text,
+  View,
+  Image,
+  TouchableHighlight,
+  NavigatorIOS
+} = React;
+
+var LoginFields = t.struct({
+  email: t.Str,
+  password: t.Str,
+
+})
+
+var options = {
+  fields: {
+    email: {
+      placeholder: 'Your email address',
+      error: 'You have to enter your email address!'
+    },
+    password: {
+      password: true,
+      secureTextEntry: true,
+      placeholder: 'Enter your password',
+      error: 'You have to enter your password!',
+    }
+  }
+}
+
+var SignUp = React.createClass({
+  onPress: function() {
+    this.props.navigator.push({
+      title: 'Chat Room',
+      component: ChatRoom
+    })
+  },
+  send: function(vaule){
+    console.log(this.props.navigatorIOS);
+  },
+  render: function() {
+    return (
+      <View style={styles.container}>
+        <View style={styles.formBox}>
+          <Form
+            ref="form"
+            type={LoginFields}
+            options={options} />
+          <TouchableHighlight style={styles.button} onPress={this.onPress} underlayColor="#99d9f4">
+            <Text style={styles.buttonText}>Sign Up</Text>
+          </TouchableHighlight>
+        </View>
+      </View>
+    )
+  }
+})
+
+module.exports = SignUp;

--- a/app/views/SignUp/index.js
+++ b/app/views/SignUp/index.js
@@ -9,16 +9,13 @@ var ChatRoom = require('../ChatRoom');
 var {
   Text,
   View,
-  Image,
-  TouchableHighlight,
-  NavigatorIOS
+  TouchableHighlight
 } = React;
 
 var LoginFields = t.struct({
   username: t.Str,
-  password: t.Str,
-
-})
+  password: t.Str
+});
 
 var options = {
   fields: {
@@ -30,20 +27,20 @@ var options = {
       password: true,
       secureTextEntry: true,
       placeholder: 'Enter your password',
-      error: 'You have to enter your password!',
+      error: 'You have to enter your password!'
     }
   }
-}
+};
 
 var SignUp = React.createClass({
   onPress: function() {
     this.props.navigator.push({
       title: 'Chat Room',
       component: ChatRoom
-    })
+    });
   },
-  send: function(vaule){
-    console.log(this.props.navigatorIOS);
+  propTypes: {
+    navigator: React.PropTypes.any
   },
   render: function() {
     return (
@@ -58,8 +55,8 @@ var SignUp = React.createClass({
           </TouchableHighlight>
         </View>
       </View>
-    )
+    );
   }
-})
+});
 
 module.exports = SignUp;

--- a/app/views/SignUp/index.js
+++ b/app/views/SignUp/index.js
@@ -15,16 +15,16 @@ var {
 } = React;
 
 var LoginFields = t.struct({
-  email: t.Str,
+  username: t.Str,
   password: t.Str,
 
 })
 
 var options = {
   fields: {
-    email: {
-      placeholder: 'Your email address',
-      error: 'You have to enter your email address!'
+    username: {
+      placeholder: 'Your username',
+      error: 'You have to enter a username!'
     },
     password: {
       password: true,

--- a/app/views/SignUp/styles.js
+++ b/app/views/SignUp/styles.js
@@ -5,7 +5,7 @@ var styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: '#ffffff',
+    backgroundColor: '#ffffff'
   },
   formBox: {
     marginTop: 50,

--- a/app/views/SignUp/styles.js
+++ b/app/views/SignUp/styles.js
@@ -5,11 +5,7 @@ var styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: '#ffffff'
-  },
-  chatBox: {
-    borderBottomWidth: 1,
-    position: 'relative'
+    backgroundColor: '#ffffff',
   },
   formBox: {
     marginTop: 50,
@@ -34,4 +30,3 @@ var styles = StyleSheet.create({
 });
 
 module.exports = styles;
-

--- a/app/views/SplashPage/index.js
+++ b/app/views/SplashPage/index.js
@@ -36,8 +36,8 @@ var SplashPage = React.createClass({
           <Text style={styles.buttonText}>Create Account</Text>
         </TouchableHighlight>
       </View>
-    )
+    );
   }
-})
+});
 
 module.exports = SplashPage;

--- a/app/views/SplashPage/index.js
+++ b/app/views/SplashPage/index.js
@@ -1,0 +1,43 @@
+var styles = require('./styles.js');
+var React = require('react-native');
+
+var SignUp = require('../SignUp');
+var Login = require('../Login');
+
+var {
+  Text,
+  View,
+  TouchableHighlight
+} = React;
+
+var SplashPage = React.createClass({
+  navLogin: function() {
+    this.props.navigator.push({
+      title: 'Log In',
+      component: Login
+    });
+  },
+  navSignup: function() {
+    this.props.navigator.push({
+      title: 'Create Account',
+      component: SignUp
+    });
+  },
+  propTypes: {
+    navigator: React.PropTypes.any
+  },
+  render: function() {
+    return (
+      <View style={styles.container}>
+        <TouchableHighlight style={styles.button} onPress={this.navLogin} underlayColor="#99d9f4">
+          <Text style={styles.buttonText}>Log In</Text>
+        </TouchableHighlight>
+        <TouchableHighlight style={styles.grayButton} onPress={this.navSignup} underlayColor="#cccccc">
+          <Text style={styles.buttonText}>Create Account</Text>
+        </TouchableHighlight>
+      </View>
+    )
+  }
+})
+
+module.exports = SplashPage;

--- a/app/views/SplashPage/styles.js
+++ b/app/views/SplashPage/styles.js
@@ -1,0 +1,42 @@
+var React = require('react-native');
+var { StyleSheet } = React;
+
+var styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ffffff'
+  },
+  formBox: {
+    marginTop: 50,
+    padding: 20,
+    position: 'relative'
+  },
+  buttonText: {
+    fontSize: 18,
+    color: 'white',
+    alignSelf: 'center'
+  },
+  button: {
+    height: 36,
+    backgroundColor: '#48BBEC',
+    borderColor: '#48BBEC',
+    borderWidth: 1,
+    borderRadius: 8,
+    marginBottom: 10,
+    alignSelf: 'flex-start',
+    justifyContent: 'space-between'
+  },
+  grayButton: {
+    height: 36,
+    backgroundColor: '#CCCCCC',
+    borderColor: '#CCCCCC',
+    borderWidth: 1,
+    borderRadius: 8,
+    marginBottom: 10,
+    alignSelf: 'flex-end',
+    justifyContent: 'space-between'
+  }
+});
+
+module.exports = styles;


### PR DESCRIPTION
- Splash Screen implemented when user launches the app
  - Two choices are 'Log In' and 'Create Account'
  - Each takes the user into its own view
  - At the end of each, takes the user into the ChatRoom view

New goals (not documented on the issue this closes):
- Hook-in authentication routes (once completed in the back-end)
- Create Account should forward user to some binary questions for matching purposes
- Style the layouts
