### PR TITLE
Crewapp/crewapp#102

### DIFF
--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -3,18 +3,66 @@ var router = require('express').Router();
 var db = require('../database');
 
 router.post('/signup', function(req, res){
-  var username = req.body.username || 'username';
-  var password = req.body.username || 'password';
+  var username = req.body.username;
+  var password = req.body.password;
 
   db.User
     .find({where: {username: username}})
     .then(function(results){
-      if(results === null){
-        /* to do */
-        res.end('add: ' + password + ' & ' + username);
+      var response;
+      if(username === undefined || password === undefined){
+        response  = {
+          response: 'failed',
+          status: 'credentials not supplied'
+        };
+      }else if(results === null && username !== 'test'){
+        response = {
+          response: 'success',
+          token: 1010,
+          group: 'crying panda'
+        };
       }else{
-        res.end(409);
+        response = {
+          response: 'failed',
+          status: 'user exists'
+        };
       }
+      res.json(response);
+    });
+});
+
+router.post('/signin', function(req, res){
+  var username = req.body.username;
+  var password = req.body.password;
+
+  db.User
+    .find({where: {username: username}})
+    .then(function(results){
+      var response;
+      if(username === undefined || password === undefined){
+        response  = {
+          response: 'failed',
+          status: 'credentials not supplied'
+        };
+      }else if(results === null && username !== 'test'){
+        response = {
+          response: 'failed',
+          status: 'user does not exist'
+        };
+      }else if(password !== 'testing'){
+        response = {
+          response: 'failed',
+          status: 'invalid credentials'
+        };
+      }else{
+        response = {
+          response: 'success',
+          token: '1010',
+          group: 'crying panda'
+        };
+      }
+      res.json(response);
+
     });
 });
 

--- a/server/groups/index.js
+++ b/server/groups/index.js
@@ -111,4 +111,5 @@ router.post('/messages', function(req, res){
   }
   res.json(response);
 });
+
 module.exports = router;

--- a/server/groups/index.js
+++ b/server/groups/index.js
@@ -2,15 +2,16 @@
 var router = require('express').Router();
 
 router.post('/', function(req, res){
+  var username = req.body.username;
   var token = req.body.token;
   var response;
 
-  if(token === undefined){
+  if(token === undefined || username === undefined){
     response = {
       response: 'failed',
       status: 'credentials not supplied'
     };
-  }else if(token === '1010'){
+  }else if(token === '1010' && username === 'test'){
     response = {
       response: 'success',
       group: 'crying panda'
@@ -25,15 +26,16 @@ router.post('/', function(req, res){
 });
 
 router.post('/leave', function(req, res){
+  var username = req.body.username;
   var token = req.body.token;
   var response;
 
-  if(token === undefined){
+  if(token === undefined || username === undefined){
     response = {
       response: 'failed',
       status: 'credentials not supplied'
     };
-  }else if(token === '1010'){
+  }else if(token === '1010' && username === 'test'){
     response = {
       response: 'success',
       group: null
@@ -48,15 +50,16 @@ router.post('/leave', function(req, res){
 });
 
 router.post('/join', function(req, res){
+  var username = req.body.username;
   var token = req.body.token;
   var response;
 
-  if(token === undefined){
+  if(token === undefined || username === undefined){
     response = {
       response: 'failed',
       status: 'credentials not supplied'
     };
-  }else if(token === '1010'){
+  }else if(token === '1010' && username === 'test'){
     response = {
       response: 'success',
       group: 'dying turtle'
@@ -70,4 +73,42 @@ router.post('/join', function(req, res){
   res.json(response);
 });
 
+router.post('/messages', function(req, res){
+  var username = req.body.username;
+  var token = req.body.token;
+  var response;
+
+  if(token === undefined || username === undefined){
+    response = {
+      response: 'failed',
+      status: 'credentials not supplied'
+    };
+  }else if(token === '1010' && username === 'test'){
+    // pull only info from user group
+    response = {
+      response: 'success',
+      group: 'dying turtle',
+      messages: [
+        {
+          'username': 'arian',
+          'message': 'hello guys'
+        },
+        {
+          'username': 'poppin3000',
+          'message': 'i love you guys'
+        },
+        {
+          'username': 'rkho',
+          'message': 'testing!!'
+        }
+      ]
+    };
+  }else{
+    response = {
+      response: 'failed',
+      status: 'invalid credentials'
+    };
+  }
+  res.json(response);
+});
 module.exports = router;

--- a/server/groups/index.js
+++ b/server/groups/index.js
@@ -1,0 +1,73 @@
+'use strict';
+var router = require('express').Router();
+
+router.post('/', function(req, res){
+  var token = req.body.token;
+  var response;
+
+  if(token === undefined){
+    response = {
+      response: 'failed',
+      status: 'credentials not supplied'
+    };
+  }else if(token === '1010'){
+    response = {
+      response: 'success',
+      group: 'crying panda'
+    };
+  }else{
+    response = {
+      response: 'failed',
+      status: 'invalid credentials'
+    };
+  }
+  res.json(response);
+});
+
+router.post('/leave', function(req, res){
+  var token = req.body.token;
+  var response;
+
+  if(token === undefined){
+    response = {
+      response: 'failed',
+      status: 'credentials not supplied'
+    };
+  }else if(token === '1010'){
+    response = {
+      response: 'success',
+      group: null
+    };
+  }else{
+    response = {
+      response: 'failed',
+      status: 'invalid credentials'
+    };
+  }
+  res.json(response);
+});
+
+router.post('/join', function(req, res){
+  var token = req.body.token;
+  var response;
+
+  if(token === undefined){
+    response = {
+      response: 'failed',
+      status: 'credentials not supplied'
+    };
+  }else if(token === '1010'){
+    response = {
+      response: 'success',
+      group: 'dying turtle'
+    };
+  }else{
+    response = {
+      response: 'failed',
+      status: 'invalid credentials'
+    };
+  }
+  res.json(response);
+});
+
+module.exports = router;

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,5 +1,6 @@
 var router = require('express').Router();
 
 router.use('/auth', require('./auth'));
+router.use('/groups', require('./groups'));
 
 module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -45,6 +45,9 @@ chatServer.listen(process.env.CHATPORT || 5000);
 //------ Our App Server ------//
 app.use(express.static(__dirname + '/../client'));
 
+// 2 for dev, 0 for production
+app.set('json spaces', 2);
+
 // Set up our body parser for query strings
 app.use(parser.urlencoded({ extended: false }));
 


### PR DESCRIPTION
Added the following routes (all post requests)

**api/auth**
- `/api/auth/signup`
  - requires: `username`, `password`
  - on success returns:
    - `response`, `token`, `group`
  - on fail returns:
    - `response`, `status`
  - username `test` already exists
- `/api/auth/signin`
  - requires: `username`, `password`
  - on success returns:
    - `response`, `token`, `group`
  - on fail returns:
    - `response`, `status`
  - username: `test` and password `testing` used for logging in

**api/groups**
- `/api/groups`
  - requires: `username`, `token`
  - on success returns:
    - `response`, `group`
  - on fail returns:
    - `response`, `status`
  - username: `test` and token `1010` used for logging in
- `/api/groups/leave`
  - requires: `username`, `token`
  - on success returns:
    - `response`, `group`
  - on fail returns:
    - `response`, `status`
  - username: `test` and token `1010` used for logging in
- `/api/groups/join`
  - requires: `username`, `token`
  - on success returns:
    - `response`, `group`
  - on fail returns:
    - `response`, `status`
  - username: `test` and token `1010` used for logging in
- `/api/groups/messages`
  - requires: `username`, `token`
  - on success returns:
    - `response`, `group`, `messages`
  - on fail returns:
    - `response`, `status`
  - username: `test` and token `1010` used for logging in
